### PR TITLE
Upgrade the ratelimiter dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,12 @@ glide: glide.tar.gz
 	ln -sf ../vendor $(GOPATH)/src
 	GOPATH=$(GOPATH) ./glide install
 
+# When you need to bump the packages as listed in glide.yaml
+glide-up: glide.tar.gz
+	tar --strip=1 -zxvf glide.tar.gz -- linux-amd64/glide
+	mkdir $(GOPATH) vendor
+	ln -sf ./vendor $(GOPATH)/src
+	GOPATH=$(GOPATH) ./glide up
+
 mendix-logfilter: glide
 	GOPATH=$(GOPATH) go build -ldflags="-s -w" -o $@ ./main.go

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,5 @@
 package: .
 import:
 - package: github.com/juju/ratelimit
-  version: 59fac5042749a5afb9af70e813da1dd5474f0167
+  version: v1.0.2
   repo: https://github.com/juju/ratelimit


### PR DESCRIPTION
We have a dependency on `github.com/juju/ratelimit` and seems like there has been couple of bug fixes on the source.
This PR includes changes
- to upgrade the dependency to v1.0.2
- add Makefile target to upgrade dependency
